### PR TITLE
build(workflow): remove add-path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
           npm i -g yarn
           yarn set version latest
           yarn config set enableTelemetry 0
-          echo "::add-path::$(yarn global bin)"
           echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache Yarn
         uses: actions/cache@v2


### PR DESCRIPTION
### Summary

- removes `add-path` from release workflow 