### PR TITLE
build: set yarn resolutions to address vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,10 @@
   },
   "optionalDependencies": {
     "ionicons": "7.4.0"
+  },
+  "resolutions": {
+    "@commitlint/is-ignored@npm:19.6.0/semver": "^7.3.5",
+    "make-dir/semver": "^6.3.1",
+    "semver-diff@npm:3.1.1/semver": "^6.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8811,12 +8811,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
+"semver@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
   bin:
-    semver: ./bin/semver.js
-  checksum: 10/8dd72e7c7cdbd8cff66b5530eeff9eec2342b127eef2c956259cdf66b85addf4829e6e4a045ca30d974d075595b0b03faa6318a597307eb3984649516b98b501
+    semver: bin/semver.js
+  checksum: 10/1ef3a85bd02a760c6ef76a45b8c1ce18226de40831e02a00bad78485390b98b6ccaa31046245fc63bba4a47a6a592b6c7eedc65cc47126e60489f9cc1ce3ed7e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR introduces Yarn resolutions in the `package.json` file to enforce specific versions of certain dependencies, ensuring compatibility and addressing potential version conflicts.

- Closes https://github.com/sbolel/sinanbolel-com/security/dependabot/87
- Closes https://github.com/sbolel/sinanbolel-com/security/dependabot/51

### Added

- Added the following resolutions to `package.json`:
  - `@commitlint/is-ignored@npm:19.6.0/semver` resolved to `^7.3.5`
  - `make-dir/semver` resolved to `^6.3.1`
  - `semver-diff@npm:3.1.1/semver` resolved to `^6.3.1`

### Changed

- Updated `yarn.lock` to reflect the new resolutions.

### Removed

- None.

### Fixed

- Addressed potential version conflicts with dependencies relying on `semver` by explicitly setting resolution versions.

## How to test

1. **Verify resolutions:**
   - Run `yarn install` and confirm that the specified resolutions are applied without errors.
   - Check the `yarn.lock` file to ensure the resolved versions match the resolutions defined in `package.json`.

2. **Validate project functionality:**
   - Test the application's primary workflows to confirm that no regressions or dependency issues were introduced.

3. **Check for warnings or errors:**
   - Run `yarn` commands and build processes to ensure no warnings or errors related to the resolved dependencies appear.