### PR TITLE
build: add resolution for cross-spawn version conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
   },
   "resolutions": {
     "@commitlint/is-ignored@npm:19.6.0/semver": "^7.3.5",
+    "cross-spawn@^6.0.5": "^6.0.6",
     "cross-spawn@^7.0.0": "^7.0.5",
     "cross-spawn@^7.0.3": "^7.0.5",
     "make-dir/semver": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,16 +2757,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "cross-spawn@npm:6.0.5"
+"cross-spawn@npm:^6.0.6":
+  version: 6.0.6
+  resolution: "cross-spawn@npm:6.0.6"
   dependencies:
     nice-try: "npm:^1.0.4"
     path-key: "npm:^2.0.1"
     semver: "npm:^5.5.0"
     shebang-command: "npm:^1.2.0"
     which: "npm:^1.2.9"
-  checksum: 10/f07e643b4875f26adffcd7f13bc68d9dff20cf395f8ed6f43a23f3ee24fc3a80a870a32b246fd074e514c8fd7da5f978ac6a7668346eec57aa87bac89c1ed3a1
+  checksum: 10/7abf6137b23293103a22bfeaf320f2d63faae70d97ddb4b58597237501d2efdd84cdc69a30246977e0c5f68216593894d41a7f122915dd4edf448db14c74171b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR resolves vulnerabilities in the `cross-spawn` package by adding a new resolution entry to `package.json`. 

### Added

- Added a resolution for `cross-spawn@^6.0.5` to enforce version `^6.0.6` in `package.json`.

### Changed

- Updated the `yarn.lock` file to reflect the added resolution and ensure consistent dependency locking.

### Removed

- None.

### Fixed

- https://github.com/sbolel/sinanbolel-com/security/dependabot/87

## How to test

1. **Install dependencies:**
   - Run `yarn install` and ensure there are no errors or warnings related to `cross-spawn`.

2. **Verify dependency resolution:**
   - Confirm the version `6.0.6` is used for `cross-spawn@^6.0.5` and `7.0.5` for `cross-spawn@^7.x`.

3. **Run tests and build:**
   - Execute the test suite and build processes to verify no regressions or issues occur due to the updated resolution.

4. **Validate functionality:**
   - Test any functionality dependent on `cross-spawn` to confirm it works as expected.