### PR TITLE
build: set yarn resolutions to address path-to-regexp vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "cross-spawn@^7.0.0": "^7.0.5",
     "cross-spawn@^7.0.3": "^7.0.5",
     "make-dir/semver": "^6.3.1",
+    "path-to-regexp@npm:^1.8.0": "^1.9.0",
     "semver-diff@npm:3.1.1/semver": "^6.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7810,12 +7810,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
+"path-to-regexp@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "path-to-regexp@npm:1.9.0"
   dependencies:
     isarray: "npm:0.0.1"
-  checksum: 10/45a01690f72919163cf89714e31a285937b14ad54c53734c826363fcf7beba9d9d0f2de802b4986b1264374562d6a3398a2e5289753a764e3a256494f1e52add
+  checksum: 10/67f0f4823f7aab356523d93a83f9f8222bdd119fa0b27a8f8b587e8e6c9825294bb4ccd16ae619def111ff3fe5d15ff8f658cdd3b0d58b9c882de6fd15bc1b76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Title

build: update resolutions for path-to-regexp dependency

PR Description

## Summary

This PR updates the `resolutions` field in `package.json` to resolve specific versions of the `path-to-regexp` package, ensuring consistency and addressing potential compatibility issues.

### Added

- Resolutions in `package.json`:
  - `path-to-regexp@npm:1.8.0` resolved to `^1.9.0`

### Changed

- Updated the `yarn.lock` file to reflect the resolution changes for `cross-spawn`.

### Removed

- None.

### Fixed

- https://github.com/sbolel/sinanbolel-com/security/dependabot/77

## How to test

1. **Verify dependency resolutions:**
   - Run `yarn` to ensure the `path-to-regexp` versions are resolved to `^1.9.0` as specified.

2. **Check project functionality:**
   - Build and run the project to confirm no regressions or dependency conflicts arise.

3. **Audit for issues:**
   - Use `yarn audit` to ensure there are no new security vulnerabilities or warnings related to the updated `cross-spawn` version.

4. **Validate lock file integrity:**
   - Ensure the updated `yarn.lock` file accurately reflects the new resolutions.